### PR TITLE
Move linking section to the end

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 include config.mk
 
 normal:
-	${CC} ${CFLAGS} ${INC} tt.c -o tt
+	${CC} ${CFLAGS} tt.c -o tt ${INC}
 
 install: normal
 	cp tt ${PREFIX}/bin


### PR DESCRIPTION
This prevents seemingly cryptic linker errors causing the build process to fail.
https://stackoverflow.com/questions/16192087/undefined-reference-to-initscr-ncurses

Error example:
![image](https://user-images.githubusercontent.com/5862812/100558002-023aca80-3272-11eb-84eb-f8bd87844630.png)